### PR TITLE
doc(hansbug): add decision-transformer related papers from ICLR 2026 and ICML 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,42 +184,42 @@ format:
 
 ### ICML 2026
 
-- [Decision Transformers As Zero-Shot Learners via Text-Behavior Alignment](https://openreview.net/forum?id=jqLPUccarO)
+- [Decision Transformers As Zero-Shot Learners via Text-Behavior Alignment](https://icml.cc/virtual/2026/poster/62096)
   - Xin Zhang, Jonathan Martinez, Yanhua Li, Yingxue Zhang
   - Key: Decision Transformer, offline meta-RL, text conditioning, zero-shot
   - ExpEnv: MetaWorld, MuJoCo
 
-- [Unsupervised Partner Design Enables Robust Ad-hoc Teamwork](https://openreview.net/forum?id=0xtMUL0eiF)
+- [Unsupervised Partner Design Enables Robust Ad-hoc Teamwork](https://arxiv.org/pdf/2508.06336v1)
   - Constantin Ruhdorfer, Matteo Bortoletto, Victor Oei, Anna Penzkofer, Andreas Bulling
   - Key: Ad-hoc teamwork, In-context coordination, Multi-agent RL
   - ExpEnv: LBF, Overcooked, OvercookedAI
 
-- [Behavior-Invariant Task Representation Learning with Transformer-based World Models for Offline Meta-Reinforcement Learning](https://openreview.net/forum?id=n4SsjVKXWQ)
+- [Behavior-Invariant Task Representation Learning with Transformer-based World Models for Offline Meta-Reinforcement Learning](https://icml.cc/virtual/2026/poster/61775)
   - Fuyuan Qian, Menglong Zhang, Song Wang, Quanying Liu
   - Key: Transformer World Model, Behavior-Invariant, Offline Meta-RL, Task Representation
   - ExpEnv: offline meta-RL benchmarks
 
-- [Benchmarking the Limits of In-Context Reinforcement Learning for Ad-Hoc Teamwork](https://openreview.net/forum?id=EbkumuY3eW)
+- [Benchmarking the Limits of In-Context Reinforcement Learning for Ad-Hoc Teamwork](https://icml.cc/virtual/2026/poster/65339)
   - Yuheng Jing, Kai Li, Jiajun Zhang, Zeyao Ma, Jiaxi Yang, Lei Zhang, Zhe Wu, Jinmin He, Junliang Xing, Jian Cheng
   - Key: In-Context RL, Ad-Hoc Teamwork, Benchmark, Multi-Agent
   - ExpEnv: Overcooked-V2
 
-- [Improving Zero-Shot Offline RL via Behavioral Task Sampling](https://openreview.net/forum?id=VqXCLPKdrp)
+- [Improving Zero-Shot Offline RL via Behavioral Task Sampling](https://arxiv.org/pdf/2604.25496v1)
   - Nazim Bendib, Nicolas Perrin-Gilbert, Olivier Sigaud
   - Key: Zero-Shot Offline RL, Behavioral Task Sampling, Meta-RL
   - ExpEnv: offline meta-RL benchmarks
 
-- [QHyer: Q-conditioned Hybrid Attention-Mamba Transformer for Offline Goal-Conditioned RL](https://openreview.net/forum?id=MGrOId7zTe)
+- [QHyer: Q-conditioned Hybrid Attention-Mamba Transformer for Offline Goal-Conditioned RL](https://arxiv.org/pdf/2605.01862v2)
   - Xing Lei, Jincheng Wang, Xuetao Zhang, Donglin Wang
   - Key: Decision Transformer, Q-Conditioned, Mamba, Offline Goal-Conditioned RL
   - ExpEnv: offline goal-conditioned RL benchmarks
 
-- [Return-to-Go Is More Than a Number: Q-Guided Alignment for Return-Conditioned Supervised Learning](https://openreview.net/forum?id=jSOVSYO6YX)
+- [Return-to-Go Is More Than a Number: Q-Guided Alignment for Return-Conditioned Supervised Learning](https://icml.cc/virtual/2026/poster/62141)
   - Yuxiao Yang, Weitong Zhang
   - Key: Return-to-Go, Decision Transformer, Q-Guided Alignment, Offline RL
   - ExpEnv: D4RL
 
-- [Robust In-Context Reinforcement Learning Under Reward Poisoning Attacks](https://openreview.net/forum?id=s8AbIVtmUg)
+- [Robust In-Context Reinforcement Learning Under Reward Poisoning Attacks](https://icml.cc/virtual/2026/poster/61251)
   - Paulius Sasnauskas, Yiğit Yalın, Goran Radanovic
   - Key: In-Context RL, Robustness, Reward Poisoning, Transformer
   - ExpEnv: in-context RL benchmarks

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Welcome to follow and star!
 - [Papers](#papers)
 
   - [Arxiv](#arxiv)
-  - [NeurIPS 2025](#neurips-2025) (**<font color="red">New!!!</font>**)
+  - [ICML 2026](#icml-2026) (**<font color="red">New!!!</font>**)
+  - [ICLR 2026](#iclr-2026) (**<font color="red">New!!!</font>**)
+  - [NeurIPS 2025](#neurips-2025)
   - [ICML 2025](#icml-2025) 
   - [ICLR 2025](#iclr-2025)
   - [NeurIPS 2024](#neurips-2024) 
@@ -179,6 +181,92 @@ format:
 - [Attention-Based Learning for Combinatorial Optimization](https://dspace.mit.edu/bitstream/handle/1721.1/144893/Smith-smithcj-meng-eecs-2022-thesis.pdf?sequence=1&isAllowed=y)
     - Carson Smith
     - Key: Combinatorial Optimization
+
+### ICML 2026
+
+- [Decision Transformers As Zero-Shot Learners via Text-Behavior Alignment](https://openreview.net/forum?id=jqLPUccarO)
+  - Xin Zhang, Jonathan Martinez, Yanhua Li, Yingxue Zhang
+  - Key: Decision Transformer, offline meta-RL, text conditioning, zero-shot
+  - ExpEnv: MetaWorld, MuJoCo
+
+- [Unsupervised Partner Design Enables Robust Ad-hoc Teamwork](https://openreview.net/forum?id=0xtMUL0eiF)
+  - Constantin Ruhdorfer, Matteo Bortoletto, Victor Oei, Anna Penzkofer, Andreas Bulling
+  - Key: Ad-hoc teamwork, In-context coordination, Multi-agent RL
+  - ExpEnv: LBF, Overcooked, OvercookedAI
+
+- [Behavior-Invariant Task Representation Learning with Transformer-based World Models for Offline Meta-Reinforcement Learning](https://openreview.net/forum?id=n4SsjVKXWQ)
+  - Fuyuan Qian, Menglong Zhang, Song Wang, Quanying Liu
+  - Key: Transformer World Model, Behavior-Invariant, Offline Meta-RL, Task Representation
+  - ExpEnv: offline meta-RL benchmarks
+
+- [Benchmarking the Limits of In-Context Reinforcement Learning for Ad-Hoc Teamwork](https://openreview.net/forum?id=EbkumuY3eW)
+  - Yuheng Jing, Kai Li, Jiajun Zhang, Zeyao Ma, Jiaxi Yang, Lei Zhang, Zhe Wu, Jinmin He, Junliang Xing, Jian Cheng
+  - Key: In-Context RL, Ad-Hoc Teamwork, Benchmark, Multi-Agent
+  - ExpEnv: Overcooked-V2
+
+- [Improving Zero-Shot Offline RL via Behavioral Task Sampling](https://openreview.net/forum?id=VqXCLPKdrp)
+  - Nazim Bendib, Nicolas Perrin-Gilbert, Olivier Sigaud
+  - Key: Zero-Shot Offline RL, Behavioral Task Sampling, Meta-RL
+  - ExpEnv: offline meta-RL benchmarks
+
+- [QHyer: Q-conditioned Hybrid Attention-Mamba Transformer for Offline Goal-Conditioned RL](https://openreview.net/forum?id=MGrOId7zTe)
+  - Xing Lei, Jincheng Wang, Xuetao Zhang, Donglin Wang
+  - Key: Decision Transformer, Q-Conditioned, Mamba, Offline Goal-Conditioned RL
+  - ExpEnv: offline goal-conditioned RL benchmarks
+
+- [Return-to-Go Is More Than a Number: Q-Guided Alignment for Return-Conditioned Supervised Learning](https://openreview.net/forum?id=jSOVSYO6YX)
+  - Yuxiao Yang, Weitong Zhang
+  - Key: Return-to-Go, Decision Transformer, Q-Guided Alignment, Offline RL
+  - ExpEnv: D4RL
+
+- [Robust In-Context Reinforcement Learning Under Reward Poisoning Attacks](https://openreview.net/forum?id=s8AbIVtmUg)
+  - Paulius Sasnauskas, Yiğit Yalın, Goran Radanovic
+  - Key: In-Context RL, Robustness, Reward Poisoning, Transformer
+  - ExpEnv: in-context RL benchmarks
+
+
+### ICLR 2026
+
+- [Vintix II: Decision Pre-Trained Transformer is a Scalable In-Context Reinforcement Learner](https://openreview.net/forum?id=t6roJiPN6Y)
+  - Andrei Polubarov, Nikita Lyubaykin, Alexander Derevyagin, Artyom Grishin, Igor Saprygin, Aleksandr Serkov, Mark Averchenko, Daniil Tikhonov, Maksim Zhdanov, Alexander Nikulin, Ilya Zisman, Albina Klepach, Alexey Zemtsov, Vladislav Kurenkov
+  - Key: In-Context RL, Decision-Pretrained Transformer, Algorithm Distillation, Flow Matching, Bayesian Posterior Sampling
+  - ExpEnv: multi-domain ICRL benchmarks
+
+- [Reward Is Enough: LLMs Are In-Context Reinforcement Learners](https://openreview.net/forum?id=keCXNHOe4W)
+  - Kefan Song, Amir Moeini, Peng Wang, Lei Gong, Rohan Chandra, Shangtong Zhang, Yanjun Qi
+  - Key: In-Context RL, LLM, Test-Time Scaling, Scalar Feedback
+  - ExpEnv: LLM reasoning, creative, scientific tasks
+
+- [Scalable In-Context Q-Learning](https://openreview.net/forum?id=NuGAhTDYTd)
+  - Jinmei Liu, Fuhong Liu, Zhenhong Sun, Jianye Hao, Huaxiong Li, Bo Wang, Daoyi Dong, Chunlin Chen, Zhi Wang
+  - Key: In-Context RL, Q-Learning, Advantage-Weighted Regression, World Model, Transformer
+  - ExpEnv: ICRL benchmarks
+
+- [In-Context Learning for Pure Exploration](https://openreview.net/forum?id=NFCNFvDYfE)
+  - Alessio Russo, Ryan Welch, Aldo Pacchiano
+  - Key: Pure Exploration, Active Sequential Hypothesis Testing, In-Context Learning, Best-Arm Identification
+  - ExpEnv: best-arm identification, generalized search benchmarks
+
+- [Offline Reinforcement Learning with Adaptive Feature Fusion](https://openreview.net/forum?id=uD9UT0gHLH)
+  - Tieru Wang, Kunbao Wu, Guoshun Nan
+  - Key: Decision Transformer, Return-Conditioned Supervised Learning, Offline RL, Trajectory Stitching
+  - ExpEnv: D4RL
+
+- [Peak-Return Greedy Slicing: Subtrajectory Selection for Transformer-based Offline RL](https://openreview.net/forum?id=7vpehpWnnY)
+  - Zhiwei Xu, Miduo Cui, Dapeng Li, Zhihao Liu, Haifeng Zhang, Hangyu Mao, Guoliang Fan, Bin Zhang
+  - Key: Transformer-Based Offline RL, Subtrajectory Selection, Return-to-Go, Stitching
+  - ExpEnv: offline RL benchmarks
+
+- [TrojanTO: Action-Level Backdoor Attacks Against Trajectory Optimization Models](https://openreview.net/forum?id=CNrU5kGJYG)
+  - Yang Dai, Oubo Ma, Xingxing Liang, Longfei Zhang, Xiaochun Cao, Shouling Ji, Jiaheng Zhang, Jincai Huang, Li Shen
+  - Key: Decision Transformer, Backdoor Attacks, Offline RL, Trajectory Optimization
+  - ExpEnv: D4RL (DT/TT)
+
+- [GAS: Enhancing Reward-Cost Balance of Generative Model-assisted Offline Safe RL](https://openreview.net/forum?id=sGrrKMK0cn)
+  - Zifan Liu, Xinran Li, Shibo Chen, Jun Zhang
+  - Key: Offline Safe RL, Constrained Decision Transformer, Trajectory Stitching, Generative Models
+  - ExpEnv: offline safe RL
+
 
 ### NeurIPS 2025
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ format:
   - Key: Decision Transformer, offline meta-RL, text conditioning, zero-shot
   - ExpEnv: MetaWorld, MuJoCo
 
-- [Unsupervised Partner Design Enables Robust Ad-hoc Teamwork](https://arxiv.org/pdf/2508.06336v1)
+- [Unsupervised Partner Design Enables Robust Ad-hoc Teamwork](https://arxiv.org/abs/2508.06336)
   - Constantin Ruhdorfer, Matteo Bortoletto, Victor Oei, Anna Penzkofer, Andreas Bulling
   - Key: Ad-hoc teamwork, In-context coordination, Multi-agent RL
   - ExpEnv: LBF, Overcooked, OvercookedAI
@@ -204,12 +204,12 @@ format:
   - Key: In-Context RL, Ad-Hoc Teamwork, Benchmark, Multi-Agent
   - ExpEnv: Overcooked-V2
 
-- [Improving Zero-Shot Offline RL via Behavioral Task Sampling](https://arxiv.org/pdf/2604.25496v1)
+- [Improving Zero-Shot Offline RL via Behavioral Task Sampling](https://arxiv.org/abs/2604.25496)
   - Nazim Bendib, Nicolas Perrin-Gilbert, Olivier Sigaud
   - Key: Zero-Shot Offline RL, Behavioral Task Sampling, Meta-RL
   - ExpEnv: offline meta-RL benchmarks
 
-- [QHyer: Q-conditioned Hybrid Attention-Mamba Transformer for Offline Goal-Conditioned RL](https://arxiv.org/pdf/2605.01862v2)
+- [QHyer: Q-conditioned Hybrid Attention-Mamba Transformer for Offline Goal-Conditioned RL](https://arxiv.org/abs/2605.01862)
   - Xing Lei, Jincheng Wang, Xuetao Zhang, Donglin Wang
   - Key: Decision Transformer, Q-Conditioned, Mamba, Offline Goal-Conditioned RL
   - ExpEnv: offline goal-conditioned RL benchmarks


### PR DESCRIPTION
## 更新内容

本 PR 为 `awesome-decision-transformer` 新增 **ICML 2026** 和 **ICLR 2026** 两个论文小节，共收录 **16 篇**与 Decision Transformer、轨迹序列建模、return-conditioned offline RL、in-context RL / offline meta-RL 相关的论文，并同步更新目录锚点。

| 会议 | 数量 | 主要覆盖方向 | 代表性论文 |
|---|---:|---|---|
| ICML 2026 | 8 | 文本-行为对齐的零样本 DT、ad-hoc teamwork 中的 in-context 协调、Transformer world model for offline meta-RL、return-to-go / Q-guided alignment、鲁棒 ICRL | Decision Transformers As Zero-Shot Learners、Unsupervised Partner Design、Transformer-based World Models for Offline Meta-RL、QHyer、Robust In-Context RL |
| ICLR 2026 | 8 | Decision-pretrained Transformer、LLM 作为 in-context RL learner、in-context Q-learning、纯探索 ICL、DT/TT 安全性与轨迹优化、离线安全 RL | Vintix II、Reward Is Enough、Scalable In-Context Q-Learning、In-Context Learning for Pure Exploration、TrojanTO、GAS |

## 收录口径

本次收录重点放在“序列模型用于决策”的论文：包括显式 Decision Transformer / Trajectory Transformer、return-conditioned supervised learning、offline meta-RL、in-context RL，以及与 DT/序列决策模型直接相关的鲁棒性、安全性和多智能体协作工作。纯机器人 diffusion policy 或只涉及一般离线 RL、但不体现序列建模/上下文学习特征的论文未纳入本 PR。

## 验证情况

- [x] ICLR 2026 新增条目链接到 OpenReview forum 页面；ICML 2026 新增条目已逐篇查找 arXiv / 开放 PDF 版本，找到 arXiv 则标题链接到 arXiv abs 页面并在 PR 评论状态列注明 PDF 存在；未发现 arXiv / 开放 PDF 的条目回退到可公开访问的 ICML virtual poster 页面。
- [x] README 条目保持本仓库既有格式：论文标题、作者、Key、ExpEnv。
- [x] 新增 ICML 2026 / ICLR 2026 目录项，并验证锚点格式与现有目录一致。
- [x] 逐篇收录理由和判定维度会在 PR 评论中补充，便于维护者 review。
